### PR TITLE
Flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,13 @@ envlist = py27, py34, py35, py36
 
 [testenv]
 commands = py.test
+           flake8 docopt.py
 deps = pytest
+       flake8
 
 [testenv:py27]
 commands = py.test
            py.test --doctest-modules docopt.py
+           flake8 docopt.py
 deps = pytest
+       flake8


### PR DESCRIPTION
@oconnor663 writes:

> I vendor docopt.py in some of my projects, and I see DeprecationWarning: invalid escape sequence when I run pytest across the whole project, because it's searching docopt.py for tests and hitting those warnings. As part of fixing that, I figured it would be nice to fix all the flake8 lints, at least in that one file. There are a few:
> 
> Those deprecated escape sequences.
> One letter variable names.
> A list comprehension variable with the same name as an outer variable (Python 2.7 only).
> Comments without a space after the #.
> I also added flake8 to tox.ini, which helped to catch that 2.7-only lint above.
> 
> If this is all too aggressive, I could rip out all of these changes except the escape sequence fixes, which is the only thing I think we genuinely need.